### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,9 @@
 name: Labeler
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/YisusChrist/codewars-solver/security/code-scanning/3](https://github.com/YisusChrist/codewars-solver/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow appears to be related to labeling (based on its name), it likely interacts with pull requests or issues. We will set the permissions to `contents: read` (a safe default) and add `pull-requests: write` and/or `issues: write` only if necessary for the labeling functionality. This ensures the workflow has the minimal permissions required to operate.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
